### PR TITLE
Update index.d.ts

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -11,7 +11,7 @@ declare module '@sambego/storybook-state/Store' {
     callbacks: Callback[];
     constructor (state: S);
     set (newState: Partial<S>): void;
-    get (key: string): any;
+    get (key?: string): any;
     subscribe (callback: Callback['callback']): string;
     unSubscribe (subscription: string): void;
   }


### PR DESCRIPTION
What: make Store.get()'s argument 'key' optional
Why: it's possible to call get() without key, which returns the whole state object